### PR TITLE
Add new commands for user management

### DIFF
--- a/cypress/dockerNode.ts
+++ b/cypress/dockerNode.ts
@@ -22,7 +22,6 @@
 
 import Docker from 'dockerode'
 import waitOn from 'wait-on'
-import path from 'path'
 
 export const docker = new Docker()
 

--- a/cypress/e2e/users.cy.ts
+++ b/cypress/e2e/users.cy.ts
@@ -52,3 +52,48 @@ describe('Create user and login', function() {
 		})
 	})
 })
+
+describe('List users and delete user', () => {
+	const hash = 'user' + randHash()
+	it(`Create '${hash}' user and delete them`, () => {
+		const user = new User(hash, 'password')
+		cy.createUser(user).then(() => {
+			cy.login(user)
+			cy.listUsers().then(users => {
+				expect(users).to.contain(user.userId)
+			})
+		})
+
+		cy.deleteUser(user).then(() => {
+			cy.listUsers().then(users => {
+				expect(users).to.not.contain(user.userId)
+			})
+		})
+	})
+
+	it('Fail deleting non existing user', () => {
+		const hash = 'nouser' + randHash()
+		const user = new User(hash, 'password')
+
+		cy.deleteUser(user).then((response) => {
+			cy.wrap(response).its('status').should('eq', 404)
+		})
+	})
+})
+
+describe('Write and read user metadata', () => {
+	const hash = 'user' + randHash()
+	it(`Create '${hash}' user and write user data`, () => {
+		const user = new User(hash, 'password')
+		cy.createUser(user).then(() => {
+			cy.login(user)
+		})
+
+		cy.modifyUser(user, 'displayname', 'John Doe')
+		cy.getUserData(user).then(response => {
+			const parser = new DOMParser();
+			const xmlDoc = parser.parseFromString(response.body, "text/xml");
+			expect(xmlDoc.querySelector('data displayname')?.textContent).to.eq('John Doe')
+		})
+	})
+})

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -21,7 +21,7 @@
  */
 import { getNc } from "./commands"
 import { login, logout } from "./commands/sessions"
-import { User, createRandomUser, createUser } from "./commands/users"
+import { User, createRandomUser, createUser, deleteUser, modifyUser, listUsers, getUserData } from "./commands/users"
 import type { Selector } from "./selectors"
 
 declare global {
@@ -32,27 +32,63 @@ declare global {
 			 * @example cy.getNc(FileList)
 			 *          cy.getNc(FileRow, { id: fileInfo.id })
 			 */
-			 getNc(selector: Selector, args?: Object): Cypress.Chainable<JQuery<HTMLElement>>
+			getNc(selector: Selector, args?: Object): Cypress.Chainable<JQuery<HTMLElement>>
 
-			 /**
-			  * Login on a Nextcloud instance
-			  */
-			 login(user: User): void
+			/**
+			 * Login on a Nextcloud instance
+			 */
+			login(user: User): void
 
-			 /**
-			  * Logout from a Nextcloud instance
-			  */
-			 logout(): void
+			/**
+			 * Logout from a Nextcloud instance
+			 */
+			logout(): void
 
-			 /**
-			  * Create a random user on the Nextcloud instance
-			  */
-			 createRandomUser(): Cypress.Chainable<User>
+			/**
+			 * Create a random user on the Nextcloud instance
+			 *
+			 * **Warning**: Using this function will reset the previous session
+			 */
+			createRandomUser(): Cypress.Chainable<User>
 
-			 /**
-			  * Create a user on the Nextcloud instance
-			  */
-			 createUser(user: User): Cypress.Chainable<Cypress.Response<any>>
+			/**
+			 * Create a user on the Nextcloud instance
+			 *
+			 * **Warning**: Using this function will reset the previous session
+			 */
+			createUser(user: User): Cypress.Chainable<Cypress.Response<any>>
+
+			/**
+			 * Delete a user on the Nextcloud instance
+			 *
+			 * **Warning**: Using this function will reset the previous session
+			 */
+			deleteUser(user: User): Cypress.Chainable<Cypress.Response<any>>
+
+			/**
+			 * Query list of users on the Nextcloud instance
+			 *
+			 * **Warning**: Using this function will reset the previous session
+			 * @returns list of user IDs
+			 */
+			listUsers(): Cypress.Chainable<string[]>
+
+			/**
+			 * Modify an attribute of a given user on the Nextcloud instance
+			 *
+			 * @param user User who modifies their metadata
+ 			 * @param key Attribute name
+ 			 * @param value New attribute value
+			 */
+			modifyUser(user: User, key: string, value: any): Cypress.Chainable<Cypress.Response<any>>
+
+			/**
+			 * 
+ 			 * Query metadata for, and in behalf, of a given user
+			 *
+			 * @param user User whom metadata to query
+			 */
+			 getUserData(user: User): Cypress.Chainable<Cypress.Response<any>>
 		}
 	}
 }
@@ -70,6 +106,10 @@ export const addCommands = function() {
 	Cypress.Commands.add('logout', logout)
 	Cypress.Commands.add('createRandomUser', createRandomUser)
 	Cypress.Commands.add('createUser', createUser)
+	Cypress.Commands.add('deleteUser', deleteUser)
+	Cypress.Commands.add('listUsers', listUsers)
+	Cypress.Commands.add('modifyUser', modifyUser)
+	Cypress.Commands.add('getUserData', getUserData)
 }
 
 export { User }


### PR DESCRIPTION
  * Added `deleteUser` for deleting existing users on the Nextcloud instance
  * Added `listUsers` for querying registered user IDs
  * Added `modifyUser` to change user metadata
  * Added `userData` to query user metadata (added mainly to test `modifyUser`)

This commands are currently used at least by the text app, but they are commonly useful also for other apps.
So I guess it would be best to integrate them into this library as a part of https://github.com/nextcloud/text/issues/2201 .