### PR TITLE
Update rollup to new major 3.6

### DIFF
--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         node-version: [ 16, 18 ]
         include:
-          - node-version: 14
+          - node-version: 16
             coverage: coverage
 
     name: test

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "AGPL-3.0-or-later",
       "devDependencies": {
         "@nextcloud/upload": "^1.1.0-beta.1",
-        "@nextcloud/webpack-vue-config": "^5.3.0",
-        "@rollup/plugin-commonjs": "^23.0.2",
+        "@nextcloud/webpack-vue-config": "^5.4.0",
+        "@rollup/plugin-commonjs": "^23.0.3",
         "@rollup/plugin-node-resolve": "^15.0.1",
         "@rollup/plugin-typescript": "^10.0.1",
         "@types/cypress": "^1.1.3",
@@ -19,18 +19,18 @@
         "@types/jest": "^29.2.2",
         "@vue/cli-service": "^5.0.8",
         "@vue/tsconfig": "^0.1.3",
-        "cypress": "^12.0.1",
+        "cypress": "12.0.1",
         "dockerode": "^3.3.4",
         "jest": "^28.1.3",
         "jest-environment-jsdom": "^29.1.2",
-        "rollup": "^2.79.1",
+        "rollup": "^3.6.0",
         "ts-jest": "^28.0.8",
-        "ts-loader": "^9.4.1",
+        "ts-loader": "^9.4.2",
         "ts-node": "^10.9.1",
         "tslib": "^2.4.1",
         "typedoc": "^0.23.15",
-        "typescript": "^4.8.4",
-        "vue": "^2.7.10",
+        "typescript": "^4.9.3",
+        "vue": "^2.7.14",
         "wait-on": "^6.0.1"
       },
       "engines": {
@@ -38,7 +38,7 @@
         "npm": "^7.0.0 || ^8.0.0"
       },
       "peerDependencies": {
-        "cypress": "^12.0.1"
+        "cypress": "12.0.1"
       }
     },
     "node_modules/@achrinza/node-ipc": {
@@ -129,12 +129,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.20.4",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.4.tgz",
-      "integrity": "sha512-luCf7yk/cm7yab6CAW1aiFnmEfBJplb/JojV56MYEK7ziWfGmFlTfmL9Ehwfy4gFhbjBfWO1wj7/TuSbVNEEtA==",
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.5.tgz",
+      "integrity": "sha512-jl7JY2Ykn9S0yj4DQP82sYvPU+T3g0HFcWTqDLqiuA9tGRNIj9VfbtXGAYTTkyNEnQk1jkMGOdYka8aG/lulCA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.20.2",
+        "@babel/types": "^7.20.5",
         "@jridgewell/gen-mapping": "^0.3.2",
         "jsesc": "^2.5.1"
       },
@@ -249,9 +249,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.18.6.tgz",
-      "integrity": "sha512-gvZnm1YAAxh13eJdkb9EWHBnF3eAub3XTLCZEehHT2kWxiKVRL64+ae5Y6Ivne0mVHmMYKT+xWgZO+gQhuLUBg==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz",
+      "integrity": "sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -618,19 +618,19 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.20.1",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.1.tgz",
-      "integrity": "sha512-d3tN8fkVJwFLkHkBN479SOsw4DMZnz8cdbL/gvuDuzy3TS6Nfw80HuQqhw1pITbIruHyh7d1fMA47kWzmcUEGA==",
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.5.tgz",
+      "integrity": "sha512-WM5ZNN3JITQIq9tFZaw1ojLU3WgWdtkxnhM1AegMS+PvHjkM5IXjmYEGY7yukz5XS4sJyEf2VzWjI8uAavhxBQ==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.20.1",
+        "@babel/generator": "^7.20.5",
         "@babel/helper-environment-visitor": "^7.18.9",
         "@babel/helper-function-name": "^7.19.0",
         "@babel/helper-hoist-variables": "^7.18.6",
         "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/parser": "^7.20.1",
-        "@babel/types": "^7.20.0",
+        "@babel/parser": "^7.20.5",
+        "@babel/types": "^7.20.5",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -638,10 +638,22 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/traverse/node_modules/@babel/parser": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.5.tgz",
+      "integrity": "sha512-r27t/cy/m9uKLXQNWWebeCUHgnAZq0CpG1OwKRxzJMP1vpSU4bSIK2hq+/cp0bQxetkXx38n09rNu8jVkcK/zA==",
+      "dev": true,
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@babel/types": {
-      "version": "7.20.2",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.2.tgz",
-      "integrity": "sha512-FnnvsNWgZCr232sqtXggapvlkk/tuwR/qhGzcmxI0GXLCjmPYQPzio2FbdlWuY6y1sHFfQKk+rRbUZ9VStQMog==",
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.5.tgz",
+      "integrity": "sha512-c9fst/h2/dcF7H+MJKZ2T0KjEQ8hY/BNnDk/H3XY8C4Aw/eWQXWn/lWntHF9ooUBnGmEvbfGrTgLWc+um0YDUg==",
       "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.19.4",
@@ -4081,16 +4093,6 @@
       "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
       "dev": true
     },
-    "node_modules/buildcheck": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.3.tgz",
-      "integrity": "sha512-pziaA+p/wdVImfcbsZLNF32EiWyujlQLwolMqUQE8xpKNOH7KmZQaY8sXN7DGOEzPAElo9QTaeNRfGnf3iOJbA==",
-      "dev": true,
-      "optional": true,
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/builtin-modules": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
@@ -4915,21 +4917,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/cpu-features": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.4.tgz",
-      "integrity": "sha512-fKiZ/zp1mUwQbnzb9IghXtHtDoTMtNeb8oYGx6kX2SYfhnG0HNdBEBIzB9b5KlXu5DQPhfy3mInbBxFcgwAr3A==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "dependencies": {
-        "buildcheck": "0.0.3",
-        "nan": "^2.15.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/create-ecdh": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
@@ -5354,9 +5341,9 @@
       "dev": true
     },
     "node_modules/cypress": {
-      "version": "12.0.2",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.0.2.tgz",
-      "integrity": "sha512-WnLx1DpnbF1vbpDBkgP14rK5yS3U+Gvxrv2fsB4Owma26oIyENj7DDRnsJbSZuTfG4mcuUJxAkRHJR2wBqBfMA==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.0.1.tgz",
+      "integrity": "sha512-I1Ag5RsPEINfUlQtV6xwkd6ktJuu5QGiKZ3pFa/IXjcyCY6I7CH3gOz0juLOhg/LXOPrQtZH35ulcWDQohyyEA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -6804,20 +6791,6 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -8189,9 +8162,9 @@
       }
     },
     "node_modules/istanbul-lib-instrument": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.0.tgz",
-      "integrity": "sha512-6Lthe1hqXHBNsqvgDzGO6l03XNeu3CrG4RqQ1KM9+l5+jNGpEJfIELx1NS3SEHmJQA8np/u+E4EPRKRiu6m19A==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
+      "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.12.3",
@@ -10120,13 +10093,6 @@
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
       }
-    },
-    "node_modules/nan": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
-      "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==",
-      "dev": true,
-      "optional": true
     },
     "node_modules/nanoid": {
       "version": "3.3.4",
@@ -12325,15 +12291,16 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.79.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
-      "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.7.0.tgz",
+      "integrity": "sha512-FIJe0msW9P7L9BTfvaJyvn1U1BVCNTL3w8O+PKIrCyiMLg+rIUGb4MbcgVZ10Lnm1uWXOTOWRNARjfXC1+M12Q==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=14.18.0",
+        "npm": ">=8.0.0"
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
@@ -13877,9 +13844,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
+      "integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -15157,12 +15124,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.20.4",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.4.tgz",
-      "integrity": "sha512-luCf7yk/cm7yab6CAW1aiFnmEfBJplb/JojV56MYEK7ziWfGmFlTfmL9Ehwfy4gFhbjBfWO1wj7/TuSbVNEEtA==",
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.5.tgz",
+      "integrity": "sha512-jl7JY2Ykn9S0yj4DQP82sYvPU+T3g0HFcWTqDLqiuA9tGRNIj9VfbtXGAYTTkyNEnQk1jkMGOdYka8aG/lulCA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.20.2",
+        "@babel/types": "^7.20.5",
         "@jridgewell/gen-mapping": "^0.3.2",
         "jsesc": "^2.5.1"
       },
@@ -15251,9 +15218,9 @@
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.18.6.tgz",
-      "integrity": "sha512-gvZnm1YAAxh13eJdkb9EWHBnF3eAub3XTLCZEehHT2kWxiKVRL64+ae5Y6Ivne0mVHmMYKT+xWgZO+gQhuLUBg==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz",
+      "integrity": "sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==",
       "dev": true
     },
     "@babel/helper-simple-access": {
@@ -15528,27 +15495,35 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.20.1",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.1.tgz",
-      "integrity": "sha512-d3tN8fkVJwFLkHkBN479SOsw4DMZnz8cdbL/gvuDuzy3TS6Nfw80HuQqhw1pITbIruHyh7d1fMA47kWzmcUEGA==",
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.5.tgz",
+      "integrity": "sha512-WM5ZNN3JITQIq9tFZaw1ojLU3WgWdtkxnhM1AegMS+PvHjkM5IXjmYEGY7yukz5XS4sJyEf2VzWjI8uAavhxBQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.20.1",
+        "@babel/generator": "^7.20.5",
         "@babel/helper-environment-visitor": "^7.18.9",
         "@babel/helper-function-name": "^7.19.0",
         "@babel/helper-hoist-variables": "^7.18.6",
         "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/parser": "^7.20.1",
-        "@babel/types": "^7.20.0",
+        "@babel/parser": "^7.20.5",
+        "@babel/types": "^7.20.5",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
+      },
+      "dependencies": {
+        "@babel/parser": {
+          "version": "7.20.5",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.5.tgz",
+          "integrity": "sha512-r27t/cy/m9uKLXQNWWebeCUHgnAZq0CpG1OwKRxzJMP1vpSU4bSIK2hq+/cp0bQxetkXx38n09rNu8jVkcK/zA==",
+          "dev": true
+        }
       }
     },
     "@babel/types": {
-      "version": "7.20.2",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.2.tgz",
-      "integrity": "sha512-FnnvsNWgZCr232sqtXggapvlkk/tuwR/qhGzcmxI0GXLCjmPYQPzio2FbdlWuY6y1sHFfQKk+rRbUZ9VStQMog==",
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.5.tgz",
+      "integrity": "sha512-c9fst/h2/dcF7H+MJKZ2T0KjEQ8hY/BNnDk/H3XY8C4Aw/eWQXWn/lWntHF9ooUBnGmEvbfGrTgLWc+um0YDUg==",
       "dev": true,
       "requires": {
         "@babel/helper-string-parser": "^7.19.4",
@@ -18346,13 +18321,6 @@
       "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
       "dev": true
     },
-    "buildcheck": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.3.tgz",
-      "integrity": "sha512-pziaA+p/wdVImfcbsZLNF32EiWyujlQLwolMqUQE8xpKNOH7KmZQaY8sXN7DGOEzPAElo9QTaeNRfGnf3iOJbA==",
-      "dev": true,
-      "optional": true
-    },
     "builtin-modules": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
@@ -18988,17 +18956,6 @@
         "yaml": "^1.10.0"
       }
     },
-    "cpu-features": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.4.tgz",
-      "integrity": "sha512-fKiZ/zp1mUwQbnzb9IghXtHtDoTMtNeb8oYGx6kX2SYfhnG0HNdBEBIzB9b5KlXu5DQPhfy3mInbBxFcgwAr3A==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "buildcheck": "0.0.3",
-        "nan": "^2.15.0"
-      }
-    },
     "create-ecdh": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
@@ -19313,9 +19270,9 @@
       "dev": true
     },
     "cypress": {
-      "version": "12.0.2",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.0.2.tgz",
-      "integrity": "sha512-WnLx1DpnbF1vbpDBkgP14rK5yS3U+Gvxrv2fsB4Owma26oIyENj7DDRnsJbSZuTfG4mcuUJxAkRHJR2wBqBfMA==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.0.1.tgz",
+      "integrity": "sha512-I1Ag5RsPEINfUlQtV6xwkd6ktJuu5QGiKZ3pFa/IXjcyCY6I7CH3gOz0juLOhg/LXOPrQtZH35ulcWDQohyyEA==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",
@@ -20456,13 +20413,6 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
-    "fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "optional": true
-    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -21454,9 +21404,9 @@
       "dev": true
     },
     "istanbul-lib-instrument": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.0.tgz",
-      "integrity": "sha512-6Lthe1hqXHBNsqvgDzGO6l03XNeu3CrG4RqQ1KM9+l5+jNGpEJfIELx1NS3SEHmJQA8np/u+E4EPRKRiu6m19A==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
+      "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.12.3",
@@ -22946,13 +22896,6 @@
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
       }
-    },
-    "nan": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
-      "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==",
-      "dev": true,
-      "optional": true
     },
     "nanoid": {
       "version": "3.3.4",
@@ -24554,9 +24497,9 @@
       }
     },
     "rollup": {
-      "version": "2.79.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
-      "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.7.0.tgz",
+      "integrity": "sha512-FIJe0msW9P7L9BTfvaJyvn1U1BVCNTL3w8O+PKIrCyiMLg+rIUGb4MbcgVZ10Lnm1uWXOTOWRNARjfXC1+M12Q==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"
@@ -25715,9 +25658,9 @@
       }
     },
     "typescript": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
+      "integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
       "dev": true
     },
     "unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "library"
   ],
   "scripts": {
-    "build": "rm -rf dist && rollup --config rollup.config.js",
+    "build": "rm -rf dist && rollup --config rollup.config.mjs",
     "build:doc": "typedoc --out dist/doc lib/commands lib/selectors lib && touch dist/doc/.nojekyll",
     "dev": "echo 'No dev build available, production only' && npm run build",
     "watch": "rollup --config rollup.config.js --watch",
@@ -62,8 +62,8 @@
   },
   "devDependencies": {
     "@nextcloud/upload": "^1.1.0-beta.1",
-    "@nextcloud/webpack-vue-config": "^5.3.0",
-    "@rollup/plugin-commonjs": "^23.0.2",
+    "@nextcloud/webpack-vue-config": "^5.4.0",
+    "@rollup/plugin-commonjs": "^23.0.3",
     "@rollup/plugin-node-resolve": "^15.0.1",
     "@rollup/plugin-typescript": "^10.0.1",
     "@types/cypress": "^1.1.3",
@@ -75,14 +75,14 @@
     "dockerode": "^3.3.4",
     "jest": "^28.1.3",
     "jest-environment-jsdom": "^29.1.2",
-    "rollup": "^2.79.1",
+    "rollup": "^3.6.0",
     "ts-jest": "^28.0.8",
-    "ts-loader": "^9.4.1",
+    "ts-loader": "^9.4.2",
     "ts-node": "^10.9.1",
     "tslib": "^2.4.1",
     "typedoc": "^0.23.15",
-    "typescript": "^4.8.4",
-    "vue": "^2.7.10",
+    "typescript": "^4.9.3",
+    "vue": "^2.7.14",
     "wait-on": "^6.0.1"
   }
 }

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -9,11 +9,7 @@ const config = (input, output) => ({
 	external,
 	plugins: [
 		nodeResolve(),
-		typescript({
-			compilerOptions: output.format === 'cjs'
-				? { target: 'es5' }
-				: {},
-		}),
+		typescript(),
 		commonjs(),
 	],
 	output: [output],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,18 +5,12 @@
 		"types": ["cypress", "node"],
 		"allowSyntheticDefaultImports": true,
 		"moduleResolution": "node",
-		"target": "es2015",
-		"module": "es2015",
+		// ES2015 is the latest version supported by cypress (besides CommonJS)
+		"target": "ES2015",
+		"module": "ES2015",
 		"declaration": true,
 		"strict": true,
 		"noImplicitAny": false,
 		"outDir": "./dist"
 	},
-	"ts-node": {
-		// these options are overrides used only by ts-node
-		// same as our --compilerOptions flag and our TS_NODE_COMPILER_OPTIONS environment variable
-		"compilerOptions": {
-			"module": "commonjs"
-		}
-	}
 }


### PR DESCRIPTION
* Updated rollup to new major version 3.x (3.6.0) and also updated corresponding dependencies
* Adjusted tsconfig to run cypress using ES modules (ES2015 is the latest supported version by cypress 11)
* Fixes / Supersedes #94 